### PR TITLE
Apply minimal Apple-like design theme

### DIFF
--- a/docs/interface.css
+++ b/docs/interface.css
@@ -787,11 +787,12 @@ p.hypnoDrone {
    border: 1px solid #ffffff;
 }
 
-/* Modern dark theme overrides */
+/* Minimal Apple‑like theme overrides */
 body {
-    background-color: #1c1c1c;
-    color: #e6e6e6;
-    font-family: "Segoe UI", Tahoma, Arial, sans-serif;
+    background-color: #f5f5f7;
+    color: #1c1c1e;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+        "Helvetica Neue", Arial, sans-serif;
     margin: 0;
 }
 
@@ -799,40 +800,51 @@ body {
     max-width: 960px;
     margin: 0 auto;
     padding: 20px;
+    animation: fade-in 0.6s ease;
 }
 
 #leftColumn, #middleColumn, #rightColumn, #topDiv, #consoleDiv {
-    background-color: #2e2e2e;
+    background-color: #ffffff;
     padding: 10px;
-    border-radius: 4px;
+    border-radius: 8px;
     margin-bottom: 10px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.05);
 }
 
 #consoleDiv {
-    color: #00ff00;
+    color: #005500;
     font-family: "Lucida Console", monospace;
 }
 
 .button, .button2 {
-    background-color: #0d6efd;
+    background-color: #007aff;
     border: none;
     color: #ffffff;
-    border-radius: 4px;
-    padding: 6px 10px;
+    border-radius: 8px;
+    padding: 8px 12px;
     cursor: pointer;
+    transition: background-color 0.3s ease, transform 0.2s ease;
 }
 
 .button:hover, .button2:hover {
-    background-color: #0b5ed7;
+    background-color: #0066d6;
+    transform: translateY(-2px);
 }
 
 .button:active, .button2:active {
-    background-color: #0a53be;
+    background-color: #005ac1;
+    transform: translateY(0);
 }
 
 .button:disabled, .button2:disabled {
-    background-color: #555555;
+    background-color: #a1a1a1;
     opacity: 0.6;
     border: none;
+    transform: none;
+}
+
+@keyframes fade-in {
+    from { opacity: 0; }
+    to { opacity: 1; }
 }
 

--- a/docs/titlescreen.css
+++ b/docs/titlescreen.css
@@ -14,10 +14,22 @@ img {
 }
 
 body {
-    background-color: #1c1c1c;
+    background-color: #f5f5f7;
+    color: #1c1c1e;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+        "Helvetica Neue", Arial, sans-serif;
     display: flex;
     align-items: center;
     justify-content: center;
     height: 100vh;
     margin: 0;
+}
+
+img {
+    animation: fade-in 0.6s ease;
+}
+
+@keyframes fade-in {
+    from { opacity: 0; }
+    to { opacity: 1; }
 }


### PR DESCRIPTION
## Summary
- refresh titlescreen style for a light minimal look
- switch interface theme to light Apple-inspired palette
- add subtle micro animations for page fade-in and button interactions

## Testing
- `bash mirror.sh` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68443c8e96d0832e8a7d23f7526c88ac